### PR TITLE
Add summary.std_dev

### DIFF
--- a/test/mobius/summary_test.exs
+++ b/test/mobius/summary_test.exs
@@ -7,6 +7,7 @@ defmodule Mobius.SummaryTest do
     expected_summary_data = %{
       reports: 1,
       accumulated: 100,
+      accumulated_sqrd: 10000,
       min: 100,
       max: 100
     }
@@ -18,6 +19,7 @@ defmodule Mobius.SummaryTest do
     expected_summary_data = %{
       reports: 1,
       accumulated: 100,
+      accumulated_sqrd: 10000,
       min: 100,
       max: 100
     }
@@ -26,7 +28,7 @@ defmodule Mobius.SummaryTest do
   end
 
   test "calculate summary from summary data" do
-    expected_summary = %{min: 100, max: 400, average: 250}
+    expected_summary = %{min: 100, max: 400, average: 250, std_dev: 212.13203435596427}
 
     summary_data =
       100


### PR DESCRIPTION
I'm not sure why std_dev isn't more common. Approximately, if "average" is the centre value, then "std dev" gives you something like the average amount that values are away from the average.

This patch adds a "naive" computation of std_deviation to the summary metric computation