### PR TITLE
Allow plotting and exporting of :summary values

### DIFF
--- a/lib/mobius/exports/metrics.ex
+++ b/lib/mobius/exports/metrics.ex
@@ -3,7 +3,7 @@ defmodule Mobius.Exports.Metrics do
 
   # Module for exporting metrics
 
-  alias Mobius.{Exports, Scraper}
+  alias Mobius.{Exports, Scraper, Summary}
 
   @doc """
   Export metrics
@@ -43,7 +43,25 @@ defmodule Mobius.Exports.Metrics do
     rows
   end
 
+  defp filter_metrics_for_metric(metrics, metric_name, :summary, tags) do
+    do_filter_metrics_for_metric(metrics, metric_name, :summary, tags)
+    |> Enum.map(fn metric ->
+      %{metric | value: metric.value |> Summary.calculate()}
+    end)
+  end
+
+  defp filter_metrics_for_metric(metrics, metric_name, {:summary, summary_metric}, tags) do
+    do_filter_metrics_for_metric(metrics, metric_name, :summary, tags)
+    |> Enum.map(fn metric ->
+      %{metric | value: metric.value |> Summary.calculate() |> Map.get(summary_metric)}
+    end)
+  end
+
   defp filter_metrics_for_metric(metrics, metric_name, type, tags) do
+    do_filter_metrics_for_metric(metrics, metric_name, type, tags)
+  end
+
+  defp do_filter_metrics_for_metric(metrics, metric_name, type, tags) do
     Enum.filter(metrics, fn metric ->
       metric_name == metric.name && match?(^tags, metric.tags) && type == metric.type
     end)


### PR DESCRIPTION
Enhances the export module to be able to export :summary values

Algorithm is to allow specification of type as {:summary, summary_value}

This allows the metrics() function to be able to export raw summary data where desired (specify type as bare :summary), and if you want a plot/csv, then use {:summary, summary_metric}