### PR TITLE
Support on demand reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run: mix compile --warnings-as-errors
       - run: mix format --check-formatted
       - run: mix deps.unlock --check-unused
-      - run: mix test
+      - run: mix test --include timeout
       - run: mix docs
       - run: mix hex.build
       - run: MIX_ENV=test mix credo -a
@@ -53,7 +53,7 @@ jobs:
       - <<: *install_system_deps
       - run: mix deps.get
       - run: mix compile
-      - run: mix test
+      - run: mix test --include timeout
 
   build_elixir_1_11_otp_23:
     docker:
@@ -65,7 +65,7 @@ jobs:
       - <<: *install_system_deps
       - run: mix deps.get
       - run: mix compile
-      - run: mix test
+      - run: mix test --include timeout
 
 workflows:
   version: 2

--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -23,6 +23,12 @@ defmodule Mobius do
      persistence data (default disabled) metric information
   * `:database` - the `Mobius.RRD.t()` to use. This will default to the the default
      values found in `Mobius.RRD`
+  * `:remote_reporter` - module that implements the `Mobius.RemoteReporter`
+    behaviour
+  * `:remote_report_interval` - if you want Mobius to trigger sending metrics at
+    an interval you can provide an interval in milliseconds. If this is not
+    configured you can trigger a metric report by calling
+    `Mobius.RemoteReporter.report_metrics/1`.
   """
   @type arg() ::
           {:mobius_instance, instance()}

--- a/lib/mobius/remote_reporter.ex
+++ b/lib/mobius/remote_reporter.ex
@@ -52,8 +52,10 @@ defmodule Mobius.RemoteReporter do
   end
   ```
 
-  If you are okay with the one minute reports you do not have to provide the
-  `:remote_report_interval` option.
+  If you do not supply a `:remote_report_interval` value the remote reporter
+  will not be ran. This is useful for programmatic on demand reporting. If you
+  want Mobius to  automatically report metrics at an interval you have to set
+  `:remote_report_interval` in the Mobius options.
   """
 
   @typedoc """
@@ -82,4 +84,12 @@ defmodule Mobius.RemoteReporter do
   """
   @callback handle_metrics([Mobius.metric()], state :: term()) ::
               {:noreply, state :: term()} | {:error, reason :: term(), state :: term()}
+
+  @doc """
+  Trigger metrics to be reported
+  """
+  @spec report_metrics(Mobius.instance()) :: :ok
+  def report_metrics(instance \\ :mobius) do
+    Mobius.RemoteReporterServer.report_metrics(instance)
+  end
 end

--- a/lib/mobius/remote_reporter_server.ex
+++ b/lib/mobius/remote_reporter_server.ex
@@ -34,19 +34,21 @@ defmodule Mobius.RemoteReporterServer do
     instance = args[:mobius_instance] || :mobius
     {reporter, reporter_args} = get_reporter(args)
     {:ok, state} = reporter.init(reporter_args)
-    report_interval = args[:report_interval] || 60_000
+    start_time = System.monotonic_time(:second)
+    report_interval = args[:report_interval]
 
-    timer_ref = Process.send_after(self(), :report, report_interval)
+    state =
+      %{
+        reporter: reporter,
+        reporter_state: state,
+        report_interval: report_interval,
+        next_query_from: nil,
+        mobius: instance,
+        start_time: start_time
+      }
+      |> maybe_start_interval()
 
-    {:ok,
-     %{
-       reporter: reporter,
-       reporter_state: state,
-       report_interval: report_interval,
-       interval_ref: timer_ref,
-       next_query_from: nil,
-       mobius: instance
-     }}
+    {:ok, state}
   end
 
   defp get_reporter(args) do
@@ -56,39 +58,87 @@ defmodule Mobius.RemoteReporterServer do
     end
   end
 
+  @doc """
+  Report the latest metrics
+
+  This function will for the latest metrics to be reported. This is useful for
+  programmatic or manually control for metrics reporting.
+  """
+  @spec report_metrics(Mobius.instance()) :: :ok
+  def report_metrics(mobius_instance \\ :mobius) do
+    name = name(mobius_instance)
+
+    GenServer.cast(name, :report_metrics)
+  end
+
+  @impl GenServer
+  def handle_cast(:report_metrics, state) do
+    {:noreply, run_report(state)}
+  end
+
   @impl GenServer
   def handle_info(:report, state) do
+    {:noreply, run_report(state)}
+  end
+
+  defp run_report(state) do
     {from, to} = get_query_window(state)
     records = Scraper.all(state.mobius, from: from, to: to)
-    new_timer_ref = Process.send_after(self(), :report, state.report_interval)
 
     case state.reporter.handle_metrics(records, state.reporter_state) do
       {:noreply, new_state} ->
-        {:noreply,
-         %{
-           state
-           | reporter_state: new_state,
-             next_query_from: to + 1,
-             interval_ref: new_timer_ref
-         }}
+        %{
+          state
+          | reporter_state: new_state,
+            next_query_from: to + 1
+        }
+        |> maybe_start_interval()
 
       {:error, _reason, new_state} ->
-        {:noreply, %{state | reporter_state: new_state, interval_ref: new_timer_ref}}
+        state = %{state | reporter_state: new_state}
+
+        maybe_start_interval(state)
     end
   end
 
-  def get_query_window(%{next_query_from: nil} = state) do
+  # if there is not a report interval and a report has not been sent yet
+  defp get_query_window(%{report_interval: nil, next_query_from: nil} = state) do
+    now_monotonic_time = System.monotonic_time(:second)
+    # the amount of time (seconds) that has pass between starting the server
+    # wanting to send the report to calculate the from timestamp.
+    time_passed = now_monotonic_time - state.start_time
+    now_time = now()
+
+    {now_time - time_passed, now_time}
+  end
+
+  # if there is not a report interval
+  defp get_query_window(%{report_interval: nil} = state) do
+    {state.next_query_from, now()}
+  end
+
+  defp get_query_window(%{next_query_from: nil} = state) do
     now = now()
     subtract = div(state.report_interval, 1000)
 
     {now - subtract, now}
   end
 
-  def get_query_window(state) do
+  defp get_query_window(state) do
     {state.next_query_from, now()}
   end
 
   defp now() do
     DateTime.to_unix(DateTime.utc_now(), :second)
+  end
+
+  defp maybe_start_interval(state) do
+    if state.report_interval do
+      timer_ref = Process.send_after(self(), :report, state.report_interval)
+
+      Map.put(state, :interval_ref, timer_ref)
+    else
+      state
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Mobius.MixProject do
       version: @version,
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps(),
       dialyzer: dialyzer(),
       description: description(),
@@ -64,6 +65,12 @@ defmodule Mobius.MixProject do
     [
       flags: [:unmatched_returns, :error_handling],
       plt_add_apps: [:eex, :mix]
+    ]
+  end
+
+  defp aliases() do
+    [
+      test: ["test --exclude timeout"]
     ]
   end
 end


### PR DESCRIPTION
Update the remote reporter logic to allow for programmatically or
manually sending remote reports when requested.

This breaks the default behavior of sending reports every minute if no
interval is provided. To upgrade a user has to explicitly set the report
interval, otherwise Mobius will not automatically send reports.

This give more control over data usage for devices that use mobile
connects or systems that need to ingest data on demand rather than in real
time.
