### PR TITLE
Add support adjusting time stamps with system clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,24 @@ end
 
 defp process_button_measurement({_, value}), do: value
 ```
+
+### Clocks
+
+For systems that lack battery-backed real-time clock which will advance the
+clock at startup to a reasonable guess, the early events will have a timestamp
+that do not make much sense. Mobius allows you to pass the `clock` argument
+which is a module that implements the `Mobius.Clock` behaviour. This behavior
+has one callback: `synchronized?/0` which returns a boolean.
+
+If a clock implementation is provide, Mobius will wait for the clock to
+synchronize before including any events into the logs. Once the clock is
+synchronized Mobius will make a best effort attempt to adjust early event
+timestamps to reflect the actual time the event occurred and will then include
+the events into the event log.
+
+If no clock implementation is provided, Mobius will assume the clock is
+synchronized and that it can trust the provided timestamps of early events.
+
+For Nerves devices, the NervesTime package can be used:
+
+`{Mobius, metrics: my_metrics, events: my_events, clock: NervesTime}`

--- a/lib/mobius/clock.ex
+++ b/lib/mobius/clock.ex
@@ -1,0 +1,26 @@
+defmodule Mobius.Clock do
+  @moduledoc """
+  Behaviour for Mobius to check if the clock is set
+
+  On systems that need to set the time after boot events and metrics might
+  report a nonsensical timestamp. Providing a clock implementation allows Mobius
+  to make time adjustments on data received before the clock was set.
+
+  If no clock implementation is provided no time adjustments will be made.
+
+  For Nerves devices, [NervesTime](https://hex.pm/packages/nerves_time) can be
+  used to time synchronization.
+
+  ```elixir
+  {Mobius, clock: NervesTime}
+  ```
+
+  The time adjustments are best effort and might not 100% exact, but this should
+  only effect events that take place during the early stages of system boot.
+  """
+
+  @doc """
+  Callback to check if the clock is synchronized
+  """
+  @callback synchronized?() :: boolean()
+end

--- a/lib/mobius/events.ex
+++ b/lib/mobius/events.ex
@@ -107,7 +107,14 @@ defmodule Mobius.Events do
         ) :: :ok
   def handle_event(event, measurements, metadata, config) do
     try do
-      process_event(config.table, event, measurements, metadata, config.event_opts)
+      process_event(
+        config.table,
+        config.session,
+        event,
+        measurements,
+        metadata,
+        config.event_opts
+      )
     rescue
       e ->
         Logger.error("Could not process event #{inspect(event)}")
@@ -117,12 +124,11 @@ defmodule Mobius.Events do
     :ok
   end
 
-  def process_event(instance, event, measurements, metadata, opts) do
+  def process_event(instance, session, event, measurements, metadata, opts) do
     measurements = process_measurements(measurements, opts)
-    ts = System.system_time(:second)
     tags = get_event_tags(metadata, opts)
 
-    event = Mobius.Event.new(event, ts, measurements, tags)
+    event = Mobius.Event.new(session, event, measurements, tags)
 
     Mobius.EventsServer.insert(instance, event)
     :ok

--- a/lib/mobius/registry.ex
+++ b/lib/mobius/registry.ex
@@ -20,19 +20,16 @@ defmodule Mobius.Registry do
   """
   @spec start_link([arg()]) :: GenServer.on_start()
   def start_link(args) do
-    ensure_metrics(args)
-
-    args = Keyword.put_new(args, :events, [])
+    args =
+      args
+      |> Keyword.put_new(:events, [])
+      |> Keyword.put_new(:metrics, [])
 
     GenServer.start_link(__MODULE__, args, name: name(args[:mobius_instance]))
   end
 
   defp name(instance) do
     Module.concat(__MODULE__, instance)
-  end
-
-  defp ensure_metrics(args) do
-    Keyword.get(args, :metrics) || raise "No :metrics defined in arguments to Mobius"
   end
 
   @doc """
@@ -81,7 +78,8 @@ defmodule Mobius.Registry do
       _ =
         :telemetry.attach(id, event, &Mobius.Events.handle_event/4, %{
           table: args[:mobius_instance],
-          event_opts: event_opts
+          event_opts: event_opts,
+          session: args[:session]
         })
 
       id

--- a/lib/mobius/time_server.ex
+++ b/lib/mobius/time_server.ex
@@ -1,0 +1,107 @@
+defmodule Mobius.TimeServer do
+  @moduledoc false
+
+  use GenServer
+
+  @doc """
+  Start the TimeServer
+  """
+  @spec start_link([Mobius.arg()]) :: GenServer.on_start()
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: name(args[:mobius_instance]))
+  end
+
+  defp name(instance) do
+    Module.concat(__MODULE__, instance)
+  end
+
+  @doc """
+  Register a pid to be notified when the clock is synced
+  """
+  @spec register(Mobius.instance(), pid()) :: :ok
+  def register(instance \\ :mobius, process) do
+    GenServer.call(name(instance), {:register, process})
+  end
+
+  @doc """
+  Check if the clock is synchronized
+  """
+  @spec synchronized?(Mobius.instance()) :: boolean()
+  def synchronized?(instance \\ :mobius) do
+    GenServer.call(name(instance), :synchronized?)
+  end
+
+  @impl GenServer
+  def init(args) do
+    started_at = System.monotonic_time()
+    started_sys_time = System.system_time()
+    session = args[:session]
+
+    state = %{
+      started_at: started_at,
+      clock: nil,
+      synced?: true,
+      registered: [],
+      started_sys_time: started_sys_time,
+      session: session
+    }
+
+    case args[:clock] do
+      nil ->
+        {:ok, state}
+
+      clock ->
+        send_check_clock_after(1_000)
+        {:ok, %{state | clock: clock, synced?: false}}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:register, pid}, _from, %{clock: nil} = state) do
+    notify(System.system_time(), 0, [pid])
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:register, pid}, _from, state) do
+    if pid in state.registered do
+      {:reply, :ok, state}
+    else
+      registered = [pid | state.registered]
+
+      {:reply, :ok, %{state | registered: registered}}
+    end
+  end
+
+  def handle_call(:synchronized?, _from, state) do
+    {:reply, state.synced?, state}
+  end
+
+  @impl GenServer
+  def handle_info(:check_clock, %{synced?: false} = state) do
+    if state.clock.synchronized?() do
+      sync_timestamp = System.system_time()
+      adjustment = sync_timestamp - state.started_sys_time
+
+      :ok = notify(sync_timestamp, adjustment, state.registered)
+
+      {:noreply, %{state | synced?: true}}
+    else
+      send_check_clock_after(1_000)
+
+      {:noreply, state}
+    end
+  end
+
+  defp notify(sync_timestamp, adjustment, registered) do
+    for pid <- registered do
+      send(pid, {__MODULE__, sync_timestamp, adjustment})
+    end
+
+    :ok
+  end
+
+  defp send_check_clock_after(timer) do
+    Process.send_after(self(), :check_clock, timer)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Mobius.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :crypto]
     ]
   end
 
@@ -34,7 +34,8 @@ defmodule Mobius.MixProject do
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:telemetry, "~> 0.4.3 or ~> 1.0"},
       {:telemetry_metrics, "~> 0.6.0"},
-      {:circular_buffer, "~> 0.4.0"}
+      {:circular_buffer, "~> 0.4.0"},
+      {:uuid, "~> 1.1"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -14,4 +14,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
 }

--- a/test/mobius/event_log_test.exs
+++ b/test/mobius/event_log_test.exs
@@ -7,7 +7,7 @@ defmodule Mobius.EventLogTest do
     gen_events =
       for event_name <- ["a.b.c", "one.two.three", "x.y.z"] do
         ts = System.system_time(:second)
-        Event.new(event_name, ts - Enum.random(1..30), %{a: 1}, %{test: true})
+        Event.new("test", event_name, ts - Enum.random(1..30), %{a: 1}, %{test: true})
       end
 
     load_event_log(:list_all, gen_events)
@@ -23,8 +23,8 @@ defmodule Mobius.EventLogTest do
 
   test "to binary works (version 1)" do
     events = [
-      Event.new("a.b.c", 123_123, %{a: 1}, %{}),
-      Event.new("d.e.f", 123_124, %{a: 1}, %{})
+      Event.new("test", "a.b.c", 123_123, %{a: 1}, %{}),
+      Event.new("test", "d.e.f", 123_124, %{a: 1}, %{})
     ]
 
     load_event_log(:to_binary_works, events)
@@ -38,8 +38,8 @@ defmodule Mobius.EventLogTest do
 
   test "parses version 1" do
     events = [
-      Event.new("a.b.c", 123_123, %{a: 1}, %{}),
-      Event.new("d.e.f", 123_124, %{a: 1}, %{})
+      Event.new("test", "a.b.c", 123_123, %{a: 1}, %{}),
+      Event.new("test", "d.e.f", 123_124, %{a: 1}, %{})
     ]
 
     bin = <<0x01, :erlang.term_to_binary(events)::binary>>
@@ -51,7 +51,7 @@ defmodule Mobius.EventLogTest do
 
   defp load_event_log(log_name, events) do
     start_supervised!(
-      {EventsServer, mobius_instance: log_name, persistence_dir: "/tmp/mobius_event_log_test"}
+      {Mobius, mobius_instance: log_name, persistence_dir: "/tmp/mobius_event_log_test"}
     )
 
     Enum.each(events, fn event -> EventsServer.insert(log_name, event) end)

--- a/test/mobius/events_test.exs
+++ b/test/mobius/events_test.exs
@@ -41,13 +41,13 @@ defmodule Mobius.EventsTest do
   describe "event handling" do
     test "basic event" do
       start_supervised!(
-        {Mobius.EventsServer,
-         mobius_instance: :basic_event, persistence_dir: "/tmp/mobius_event_log"}
+        {Mobius, mobius_instance: :basic_event, persistence_dir: "/tmp/mobius_event_log"}
       )
 
       config = %{
         table: :basic_event,
-        event_opts: []
+        event_opts: [],
+        session: "test"
       }
 
       :ok = Events.handle_event("a.b.c", %{a: 1}, %{t: 1}, config)
@@ -61,13 +61,13 @@ defmodule Mobius.EventsTest do
 
     test "filter for tags" do
       start_supervised!(
-        {Mobius.EventsServer,
-         mobius_instance: :filter_for_tags, persistence_dir: "/tmp/mobius_event_log"}
+        {Mobius, mobius_instance: :filter_for_tags, persistence_dir: "/tmp/mobius_event_log"}
       )
 
       config = %{
         table: :filter_for_tags,
-        event_opts: [tags: [:t]]
+        event_opts: [tags: [:t]],
+        session: "test"
       }
 
       :ok = Events.handle_event("a.b.c", %{a: 1}, %{t: 1, z: 2}, config)
@@ -81,13 +81,13 @@ defmodule Mobius.EventsTest do
 
     test "process measurements" do
       start_supervised!(
-        {Mobius.EventsServer,
-         mobius_instance: :process_measurements, persistence_dir: "/tmp/mobius_event_log"}
+        {Mobius, mobius_instance: :process_measurements, persistence_dir: "/tmp/mobius_event_log"}
       )
 
       config = %{
         table: :process_measurements,
-        event_opts: [tags: [:t], measurements_values: &event_measurement_processor/1]
+        event_opts: [tags: [:t], measurements_values: &event_measurement_processor/1],
+        session: "test"
       }
 
       :ok = Events.handle_event("a.b.c", %{a: 1, b: 1}, %{t: 1, z: 2}, config)


### PR DESCRIPTION
For devices who have to synchronize their clock the early timestamps
will make no sense. This adds support to handle events that happen
before the clock is synchronized and to adjust their timestamps after
the clock is synchronized.
